### PR TITLE
FEAT: add account id

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24,6 +24,15 @@ paths:
           schema:
             type: string
           description: The body of the email.
+        - name: accountId
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+            maximum: 100
+          description: The account ID for the Gmail account, ranging from 0 to 100. Defaults to 0 if not provided or invalid.
       responses:
         "200":
           description: Successful response

--- a/routes/createGmailUrl/index.ts
+++ b/routes/createGmailUrl/index.ts
@@ -1,7 +1,12 @@
 export default eventHandler((event) => {
   const subjectLine = getQuery(event).subjectLine || "undefinedSubject";
   const emailBody = getQuery(event).emailBody || "undefinedBody";
-  const accountId = getQuery(event).emailBody || 0;
+  let accountId = parseInt(getQuery(event).accountId) || 0;
+
+  // Check if conversion failed or if accountId is out of range, then default to 0
+  if (isNaN(accountId) || accountId < 0 || accountId > 100) {
+    accountId = 0;
+  }
 
   // Ensure inputs are URL-safe
   const encodedSubject = encodeURIComponent(subjectLine.toString());


### PR DESCRIPTION
allow users to provide the id of the gmail account they want to use. account ids in gmail urls are 0-indexed.

use case:
- useful when signed into multiple accounts and want to open the email in a specific account.